### PR TITLE
fix: タイムゾーンを日本時間(JST)に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,20 +8,11 @@ Bundler.require(*Rails.groups)
 
 module GakushuuLogger
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.autoload_lib(ignore: %w[assets tasks])
   end
 end


### PR DESCRIPTION
### 概要
<!-- このPRで何を変更したかを簡潔に -->
本番環境にて学習開始時の時刻が9時間ズレていたのでタイムゾーンを日本時間に修正しました。

